### PR TITLE
Align wrappers

### DIFF
--- a/components/js/lib/go-contentwidgets.js
+++ b/components/js/lib/go-contentwidgets.js
@@ -67,6 +67,30 @@ if ( 'undefined' === typeof go_contentwidgets ) {
 			}//end else
 		});
 
+		$( '.alignleft' ).each( function() {
+			var $el = $( this );
+			var width = $el.outerWidth( false );
+
+			if ( $el.closest( '.aligncenter' ).length ) {
+				return;
+			}//end if
+
+			$el.wrap( '<div class="go-contentwidgets-align-container go-contentwidgets-alignleft"/>' );
+			$el.css( 'height', 'auto' );
+		});
+
+		$( '.alignright' ).each( function() {
+			var $el = $( this );
+			var width = $el.outerWidth( false );
+
+			if ( $el.closest( '.aligncenter' ).length ) {
+				return;
+			}//end if
+
+			$el.wrap( '<div class="go-contentwidgets-align-container go-contentwidgets-alignright"/>' );
+			$el.css( 'height', 'auto' );
+		});
+
 		this.collect_widgets();
 
 		this.auto_inject();


### PR DESCRIPTION
Add wrappers to items aligned to the right and left so they can be styled/aligned properly. (Allows for aligning to the inner edge)

See: https://github.com/GigaOM/gigaom/issues/5353
