### PR TITLE
Force all images to have a height, but remove it when layout is complete

### DIFF
--- a/components/js/lib/go-contentwidgets.js
+++ b/components/js/lib/go-contentwidgets.js
@@ -289,7 +289,7 @@ if ( 'undefined' === typeof go_contentwidgets ) {
 
 		// manual heights were added to all images to enable proper insertion. Let's remove the manual heights
 		// so our CSS will work as expected
-		this.$images.css( 'height', 'auto' );
+		this.$images.css( 'height', '' );
 
 		this.full_inject_complete = true;
 	};


### PR DESCRIPTION
See: https://github.com/GigaOM/gigaom/issues/5777

This was logic that was in this plugin before but was stripped out when it screwed with our CSS.  The fix is to add it back in (in a better location) and remove the manually set heights once layout has completed.
