### PR TITLE
Fix left blocker weirdness

### DIFF
--- a/components/js/lib/go-contentwidgets.js
+++ b/components/js/lib/go-contentwidgets.js
@@ -534,7 +534,7 @@ if ( 'undefined' === typeof go_contentwidgets ) {
 
 			var end = injection_gap.end < injectable_attrs.end ? injection_gap.end : injectable_attrs.end;
 
-			if ( this.left_blocker_in_gap( injectable.$el.next(), end ) ) {
+			if ( this.left_blocker_in_gap( $injection_point, end ) ) {
 				injectable.$el.removeClass( 'layout-box-insert-left' ).addClass( 'layout-box-insert-right' );
 			}//end if
 		}//end if


### PR DESCRIPTION
Firstly, we weren't ever returning `true`.

The other issue was that if the intersected element was a left blocker but it extended below the bottom of the injected unit, we weren't identifying it as a blocker.

I also added `<ol>` tags as left blockers.

See: https://github.com/GigaOM/gigaom/issues/5781 and https://github.com/GigaOM/gigaom/issues/5772
