### PR TITLE
Identify a tweet by the class "twitter-tweet", not "twitter-embed"

### DIFF
--- a/components/js/lib/go-contentwidgets.js
+++ b/components/js/lib/go-contentwidgets.js
@@ -11,7 +11,7 @@ if ( 'undefined' === typeof go_contentwidgets ) {
 	go_contentwidgets.full_inject_complete = false;
 	go_contentwidgets.current = Date.now();
 	// set up blackout selectors. NOTE: blockquotes are not blackouts except when they are tweet-embeds
-	go_contentwidgets.blackout_selector = '> *:not(p,blockquote:not(.tweet-embed),h1,h2,h3,h4,h5,h6,ol,ul,script,address)';
+	go_contentwidgets.blackout_selector = '> *:not(p,blockquote:not(.twitter-tweet),h1,h2,h3,h4,h5,h6,ol,ul,script,address)';
 
 	go_contentwidgets.log = function( text ) {
 		go_contentwidgets.current = Date.now();


### PR DESCRIPTION
Followup changeset for https://github.com/GigaOM/go-contentwidgets/issues/17

![screen shot 2014-11-03 at 6 30 49 pm](https://cloud.githubusercontent.com/assets/430385/4892388/a6286de6-63b1-11e4-9dfc-8a8536ecf109.png)

See: https://github.com/GigaOM/gigaom/issues/5852
