### PR TITLE
Construct accurate gaps and inject ONLY into the gap

### DIFF
--- a/components/js/lib/go-contentwidgets.js
+++ b/components/js/lib/go-contentwidgets.js
@@ -609,6 +609,7 @@ if ( 'undefined' === typeof go_contentwidgets ) {
 		var $injection_point = null;
 		var gap = null;
 		var injection_gap = null;
+		var $tmp;
 		go_contentwidgets.log( 'injecting injectable' );
 
 		for ( i = 0, length = this.inventory.gaps.length; i < length; i++ ) {
@@ -623,7 +624,16 @@ if ( 'undefined' === typeof go_contentwidgets ) {
 					var next_injection_point = this.attributes( $injection_point );
 					while ( next_injection_point.end <= gap.end && ( gap.end - next_injection_point.start ) > injectable.height ) {
 						$injection_point = next_injection_point.$el;
-						next_injection_point = this.attributes( $injection_point.next() );
+
+						// we need to make sure we aren't selecting a blackout overlay
+						$tmp = $injection_point.next( ':not(.layout-box-thing)' );
+
+						// if there's nothing else to select, then we're done searching for an injection point
+						if ( ! $tmp.length ) {
+							break;
+						}//end if
+
+						next_injection_point = this.attributes( $tmp );
 					}// end while
 					injection_gap = gap;
 				}//end if


### PR DESCRIPTION
### When constructing a gap, recalculate the height based on first el in gap

When we found a gap, we were blindly taking the entire gap height as the available space for an injection, when in reality the available space is based off of the location of _first element that can have something injected next to it_.

`AvailableSpace = GapHeight - ( YPosOfFirstElementInGap - PreviousBlackoutEndYPos )`
### Don't inject outside of the gap

As we look for an injection point from bottom-up, don't consider `.layout-box-thing` an injection point.

See: https://github.com/GigaOM/gigaom/issues/5969, https://github.com/GigaOM/gigaom/issues/5848, https://github.com/GigaOM/gigaom/issues/5765

---
#### Doesn't attempt to inject right before the gallery (where it was [doing so before](https://github.com/GigaOM/gigaom/issues/5848#issuecomment-61906874)):

![screen shot 2014-11-05 at 9 54 21 pm](https://cloud.githubusercontent.com/assets/430385/4930185/421b9426-6560-11e4-88d8-41c19868e17d.png)
#### Doesn't attempt to inject in the last paragraph (because there isn't room) where it was [doing so before](https://github.com/GigaOM/gigaom/issues/5969):

![screen shot 2014-11-05 at 9 58 23 pm](https://cloud.githubusercontent.com/assets/430385/4930223/eaa1de0c-6560-11e4-9828-a38805b515da.png)
#### Don't accidentally inject before an go-contentwidgets overlay when injecting from the bottom (it was [doing that before](https://github.com/GigaOM/gigaom/issues/5765#issuecomment-61908324))

![screen shot 2014-11-05 at 10 31 29 pm](https://cloud.githubusercontent.com/assets/430385/4930514/6c1b3344-6565-11e4-8046-9a8006cf6142.png)
