### PR TITLE
Better space balancing logic that takes child elements into account

### DIFF
--- a/components/js/lib/go-contentwidgets.js
+++ b/components/js/lib/go-contentwidgets.js
@@ -386,6 +386,13 @@ if ( 'undefined' === typeof go_contentwidgets ) {
 			// add two classes to look for at the end of the selector
 			sibling_selector = sibling_selector.replace( /\)$/, ',span,a,.go-contentwidgets-spacer,.layout-box-thing)' );
 
+			// if the injectable is on the left, we need to consider blockquotes, uls, and ols as blockers
+			if ( $el.is( '.layout-box-insert-left' ) ) {
+				sibling_selector = sibling_selector.replace( ',blockquote', '' );
+				sibling_selector = sibling_selector.replace( ',ul', '' );
+				sibling_selector = sibling_selector.replace( ',ol', '' );
+			}//end if
+
 			// find the previous and next blocking elements
 			var $maybe_prev = $el.prevAll( '*' );
 			var $maybe_next = $el.nextAll( '*' );

--- a/components/js/lib/go-contentwidgets.js
+++ b/components/js/lib/go-contentwidgets.js
@@ -782,7 +782,7 @@ if ( 'undefined' === typeof go_contentwidgets ) {
 				});
 
 				// let's store off the next injection point because we'll probably need it
-				var $next = $injection_point.next();
+				var $next = $injection_point.next( ':not(.layout-box-insert,.layout-box-thing)' );
 
 				// external_height holds the total gap height that isn't the gap we're in
 				var external_height = total_gap_height - gap.height;
@@ -810,7 +810,7 @@ if ( 'undefined' === typeof go_contentwidgets ) {
 				) {
 					// Yup! move the injection point
 					$injection_point = $next;
-					$next = $injection_point.next();
+					$next = $injection_point.next( ':not(.layout-box-insert,.layout-box-thing)' );
 				}//end while
 
 				if ( injectable.preferbottom ) {

--- a/components/js/lib/go-contentwidgets.js
+++ b/components/js/lib/go-contentwidgets.js
@@ -383,7 +383,7 @@ if ( 'undefined' === typeof go_contentwidgets ) {
 
 			var sibling_selector = go_contentwidgets.blackout_selector.replace( '> ', '' );
 
-			// add two classes to look for at the end of the selector
+			// add two classes and some other inline elements to look for at the end of the selector
 			sibling_selector = sibling_selector.replace( /\)$/, ',span,a,.go-contentwidgets-spacer,.layout-box-thing)' );
 
 			// if the injectable is on the left, we need to consider blockquotes, uls, and ols as blockers
@@ -424,7 +424,7 @@ if ( 'undefined' === typeof go_contentwidgets ) {
 				}//end else
 			});
 
-			// if there is a previous and a next, let's try to balance the element
+			// if there isn't a previous, let's bail and not try to balance the element
 			if ( ! $prev.length ) {
 				return;
 			}//end if

--- a/components/js/lib/go-contentwidgets.js
+++ b/components/js/lib/go-contentwidgets.js
@@ -373,31 +373,69 @@ if ( 'undefined' === typeof go_contentwidgets ) {
 		this.$images.css( 'height', '' );
 
 		// now that we've inserted everything, let's balance the items out
-		var $injected = $( '.layout-box-insert' );
+		var $injected = go_contentwidgets.$content.find( '.layout-box-insert' );
 		$injected.each( function( i ) {
 			var $el = $( this );
 
-			if ( 0 === i || $injected.length === i - 1 ) {
+			if ( 0 === i ) {
 				return;
 			}//end if
 
 			var sibling_selector = go_contentwidgets.blackout_selector.replace( '> ', '' );
 
 			// add two classes to look for at the end of the selector
-			sibling_selector = sibling_selector.replace( /\)$/, ',.go-contentwidgets-spacer,.layout-box-thing)' );
+			sibling_selector = sibling_selector.replace( /\)$/, ',span,a,.go-contentwidgets-spacer,.layout-box-thing)' );
 
 			// find the previous and next blocking elements
-			var $prev = $el.prevAll( sibling_selector );
-			var $next = $el.nextAll( sibling_selector );
+			var $maybe_prev = $el.prevAll( '*' );
+			var $maybe_next = $el.nextAll( '*' );
+
+			var $prev = $();
+			var $next = $();
+
+			// we need to manually build the prev collection because sometimes we have blockers as children of other non-blocking elements (p, ul, ol)
+			$maybe_prev.each( function() {
+				var $current = $( this );
+				if ( $current.is( sibling_selector ) ) {
+					$prev = $prev.add( $current );
+				} else {
+					if ( $current.is( 'p,ul,ol,blockquote' ) ) {
+						$prev = $prev.add( $current.find( sibling_selector ) );
+					}//end if
+				}//end else
+			});
+
+			// we need to manually build the next collection because sometimes we have blockers as children of other non-blocking elements (p, ul, ol)
+			$maybe_next.each( function() {
+				var $current = $( this );
+				if ( $current.is( sibling_selector ) ) {
+					$next = $next.add( $current );
+				} else {
+					if ( $current.is( 'p,ul,ol,blockquote' ) ) {
+						$next = $next.add( $current.find( sibling_selector ) );
+					}//end if
+				}//end else
+			});
 
 			// if there is a previous and a next, let's try to balance the element
-			if ( ! $prev.length || ! $next.length ) {
+			if ( ! $prev.length ) {
 				return;
 			}//end if
 
+			// reverse the prev collection so the first element is the closet to the injectable
+			$prev = $( $prev.get().reverse() );
+
 			var el_height = parseInt( $el.outerHeight( true ), 10 );
 			var above = $el.get( 0 ).offsetTop - ( $prev.get( 0 ).offsetTop + parseInt( $prev.outerHeight( true ), 10 ) );
-			var below = $next.get( 0 ).offsetTop - ( $el.get( 0 ).offsetTop + el_height );
+			var below;
+
+			if ( $next.length ) {
+				// if there are more blockers after this one, compute the distance that is shiftable based on the next item
+				below = $next.get( 0 ).offsetTop - ( $el.get( 0 ).offsetTop + el_height );
+			} else {
+				// if this is the last item in the post, then use the bottom of the post to compute the shiftable distance
+				below = parseInt( go_contentwidgets.$content.outerHeight( true ), 10 ) - ( $el.get( 0 ).offsetTop + el_height );
+			}//end else
 
 			// if there is less space above the injected item than there is below, attempt to even that out a bit
 			if ( above < below ) {
@@ -515,7 +553,7 @@ if ( 'undefined' === typeof go_contentwidgets ) {
 	go_contentwidgets.adjust_down = function( $injectable, distance ) {
 		var alignment_class = 'layout-box-insert-right';
 
-		distance = Math.round( distance / 8 ) * 8;
+		distance = Math.round( distance / 27 ) * 27;
 
 		if ( ! $injectable.hasClass( alignment_class ) ) {
 			alignment_class = 'layout-box-insert-left';


### PR DESCRIPTION
See: https://github.com/GigaOM/gigaom/issues/6569, https://github.com/GigaOM/gigaom/issues/6565, and https://github.com/GigaOM/gigaom/issues/6480

### Example from ticket #6569
![screen shot 2015-01-22 at 3 27 14 pm](https://cloud.githubusercontent.com/assets/430385/5863942/8e7f7ed6-a24b-11e4-8c1c-b1dfdcdec38c.png)

### Another example with no images
![screen shot 2015-01-22 at 3 29 21 pm](https://cloud.githubusercontent.com/assets/430385/5863943/92191eda-a24b-11e4-9548-f1d0f2a6d198.png)

### Another example with different ads
![screen shot 2015-01-22 at 3 29 42 pm](https://cloud.githubusercontent.com/assets/430385/5863944/94ad2ef2-a24b-11e4-804e-3c9fc610a6d7.png)

### Spacing around blockquotes with left aligned elements
![screen shot 2015-01-22 at 4 29 37 pm](https://cloud.githubusercontent.com/assets/430385/5864957/f8c8a670-a253-11e4-8386-d8aa0d3f7875.png)